### PR TITLE
[feat] create and apply profile context

### DIFF
--- a/api/supabase/queries/profiles.ts
+++ b/api/supabase/queries/profiles.ts
@@ -1,3 +1,4 @@
+import { UUID } from 'crypto';
 import { Profile } from '@/types/schema';
 import supabase from '../createClient';
 
@@ -9,6 +10,19 @@ export async function upsertProfile(profile: Profile) {
     .single();
 
   if (error) throw new Error(`Error upserting profile data: ${error.message}`);
+
+  return data;
+}
+
+export async function fetchProfileById(userId: UUID) {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('user_id', userId)
+    .single();
+
+  if (error)
+    throw new Error(`Error fetching profile id ${userId}: ${error.message}`);
 
   return data;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import StyledComponentsRegistry from '@/lib/registry';
+import ProfileProvider from '@/utils/ProfileProvider';
 import { AuthProvider } from '../utils/AuthProvider';
 
 // font definitions
@@ -24,7 +25,9 @@ export default function RootLayout({
     <html lang="en">
       <body className={sans.className}>
         <AuthProvider>
-          <StyledComponentsRegistry>{children}</StyledComponentsRegistry>
+          <ProfileProvider>
+            <StyledComponentsRegistry>{children}</StyledComponentsRegistry>
+          </ProfileProvider>
         </AuthProvider>
       </body>
     </html>

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -5,48 +5,54 @@ import { upsertProfile } from '@/api/supabase/queries/profiles';
 import { BigButton } from '@/components/Buttons';
 import LabeledCustomSelect from '@/components/EditableInput';
 import COLORS from '@/styles/colors';
-import { DropdownOption, Profile } from '@/types/schema';
+import { DropdownOption, Profile, UserTypeEnum } from '@/types/schema';
 import { H3, PageContainer, ReviewContainer } from './styles';
 
 // Define the possible options for each question
-const states = [
-  { label: 'Tennesse', value: 'TENNESSE' },
+const stateOptions: DropdownOption<string>[] = [
+  { label: 'Tennessee', value: 'TENNESSE' },
   { label: 'Missouri', value: 'MISSOURI' },
 ];
-const gardenTypes = ['Individual', 'Community', 'School'];
-const plotOptions = [
-  { label: 'yes', value: true },
-  { label: 'no', value: false },
+
+const gardenTypeOptions: DropdownOption<UserTypeEnum>[] = [
+  { label: 'Individual', value: 'INDIV' },
+  { label: 'Community', value: 'ORG' },
+  { label: 'School', value: 'SCHOOL' },
 ];
-//Interfaces and props to avoid typ errors on Lint
+
+const plotOptions: DropdownOption<boolean>[] = [
+  { label: 'Yes, I own a plot', value: true },
+  { label: "No, I don't own a plot", value: false },
+];
+
 interface StateSelectionProps {
-  selectedState: string;
-  setSelectedState: React.Dispatch<React.SetStateAction<string>>;
+  selectedState: string | undefined; // undefined b/c <select> only accepts undefined
+  setSelectedState: (selected: string) => void;
 }
 
 interface GardenTypeSelectionProps {
-  selectedGardenType: string;
-  setSelectedGardenType: React.Dispatch<React.SetStateAction<string>>;
+  selectedGardenType: UserTypeEnum | undefined;
+  setSelectedGardenType: (selected: UserTypeEnum) => void;
 }
 
 interface PlotSelectionProps {
-  selectedPlot: boolean | null;
-  setSelectedPlot: React.Dispatch<React.SetStateAction<boolean>>;
+  selectedPlot: boolean | undefined;
+  setSelectedPlot: (selected: boolean) => void;
 }
 interface ReviewPageProps {
-  selectedState: string;
-  setSelectedState: React.Dispatch<React.SetStateAction<string>>;
-  selectedGardenType: string;
-  setSelectedGardenType: React.Dispatch<React.SetStateAction<string>>;
-  selectedPlot: boolean;
-  setSelectedPlot: React.Dispatch<React.SetStateAction<boolean>>;
+  selectedState: string | undefined;
+  setSelectedState: (selected: string) => void;
+  selectedGardenType: UserTypeEnum | undefined;
+  setSelectedGardenType: (selected: UserTypeEnum) => void;
+  selectedPlot: boolean | undefined;
+  setSelectedPlot: (selected: boolean) => void;
 }
 
-// Select State
-const StateSelection: React.FC<StateSelectionProps> = ({
+// Step 1: Select State
+const StateSelection = ({
   selectedState,
   setSelectedState,
-}) => {
+}: StateSelectionProps) => {
   return (
     <div>
       <h2>Which state do you live in?</h2>
@@ -57,7 +63,7 @@ const StateSelection: React.FC<StateSelectionProps> = ({
         <option value="" disabled>
           Select a state
         </option>
-        {states.map(state => (
+        {stateOptions.map(state => (
           <option key={state.label} value={state.value}>
             {state.label}
           </option>
@@ -68,24 +74,25 @@ const StateSelection: React.FC<StateSelectionProps> = ({
 };
 
 // Step 2: Select garden type
-
-const GardenTypeSelection: React.FC<GardenTypeSelectionProps> = ({
+const GardenTypeSelection = ({
   selectedGardenType,
   setSelectedGardenType,
-}) => {
+}: GardenTypeSelectionProps) => {
   return (
     <div>
       <h2>What type of garden do you want to create?</h2>
-      {gardenTypes.map(type => (
-        <label key={type}>
+      {gardenTypeOptions.map(type => (
+        <label key={type.label}>
           <input
             type="radio"
             name="gardenType"
-            value={type}
-            checked={selectedGardenType === type}
-            onChange={e => setSelectedGardenType(e.target.value)}
+            value={type.value}
+            checked={selectedGardenType === type.value}
+            onChange={e =>
+              setSelectedGardenType(e.target.value as UserTypeEnum)
+            }
           />
-          {type}
+          {type.label}
         </label>
       ))}
     </div>
@@ -93,10 +100,10 @@ const GardenTypeSelection: React.FC<GardenTypeSelectionProps> = ({
 };
 
 // Step 3: Do you have a plot?
-const PlotSelection: React.FC<PlotSelectionProps> = ({
+const PlotSelection = ({
   selectedPlot,
   setSelectedPlot,
-}) => {
+}: PlotSelectionProps) => {
   return (
     <div>
       <h2>Do you already have a plot?</h2>
@@ -115,23 +122,6 @@ const PlotSelection: React.FC<PlotSelectionProps> = ({
     </div>
   );
 };
-const stateOptions: DropdownOption<string>[] = [
-  { label: 'Tennessee', value: 'TENNESSE' },
-  { label: 'Missouri', value: 'MISSOURI' },
-];
-
-const gardenTypeOptions: DropdownOption<string>[] = [
-  { label: 'Individual', value: 'Individual' },
-  { label: 'Community', value: 'Community' },
-  { label: 'School', value: 'School' },
-];
-
-const plot: DropdownOption<boolean>[] = [
-  { label: 'Yes, I own a plot', value: true },
-  { label: "No, I don't own a plot", value: false },
-];
-
-// Updated ReviewPage component to accept necessary props
 
 const ReviewPage = ({
   selectedState,
@@ -144,8 +134,8 @@ const ReviewPage = ({
   const handleSubmit = async () => {
     const profile: Profile = {
       user_id: '2abd7296-374a-42d1-bb4f-b813da1615ae',
-      us_state: selectedState,
-      user_type: selectedGardenType,
+      us_state: selectedState!,
+      user_type: selectedGardenType!,
       // has_plot: selectedPlot,
     };
 
@@ -163,21 +153,21 @@ const ReviewPage = ({
         <H3 style={{ textAlign: 'center' }}>Review Your Response</H3>
         <LabeledCustomSelect
           label="State Location"
-          value={selectedState}
+          value={selectedState!}
           options={stateOptions}
           onChange={setSelectedState}
         />
 
         <LabeledCustomSelect
           label="Garden Type"
-          value={selectedGardenType}
+          value={selectedGardenType!}
           options={gardenTypeOptions}
           onChange={setSelectedGardenType} // Directly pass the selected value
         />
         <LabeledCustomSelect
           label="Plot Status"
-          value={selectedPlot}
-          options={plot}
+          value={selectedPlot!}
+          options={plotOptions}
           onChange={value => setSelectedPlot(value === true)} // Convert the value as needed
         />
         <div style={{ height: '12.625rem' }} />
@@ -190,11 +180,15 @@ const ReviewPage = ({
 };
 
 // Main Onboarding Component
-const OnboardingFlow = () => {
+export default function OnboardingFlow() {
   const [step, setStep] = useState(1);
   const [selectedState, setSelectedState] = useState<string>('');
-  const [selectedGardenType, setSelectedGardenType] = useState<string>('');
-  const [selectedPlot, setSelectedPlot] = useState<boolean>(false);
+  const [selectedGardenType, setSelectedGardenType] = useState<
+    UserTypeEnum | undefined
+  >(undefined);
+  const [selectedPlot, setSelectedPlot] = useState<boolean | undefined>(
+    undefined,
+  );
 
   const handleNext = () => {
     setStep(step + 1);
@@ -244,6 +238,4 @@ const OnboardingFlow = () => {
       </div>
     </div>
   );
-};
-
-export default OnboardingFlow;
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,16 +1,16 @@
 'use client';
 
 import React, { useState } from 'react';
-import { upsertProfile } from '@/api/supabase/queries/profiles';
 import { BigButton } from '@/components/Buttons';
 import LabeledCustomSelect from '@/components/EditableInput';
 import COLORS from '@/styles/colors';
 import { DropdownOption, Profile, UserTypeEnum } from '@/types/schema';
+import { useProfile } from '@/utils/ProfileProvider';
 import { H3, PageContainer, ReviewContainer } from './styles';
 
 // Define the possible options for each question
 const stateOptions: DropdownOption<string>[] = [
-  { label: 'Tennessee', value: 'TENNESSE' },
+  { label: 'Tennessee', value: 'TENNESSEE' },
   { label: 'Missouri', value: 'MISSOURI' },
 ];
 
@@ -40,11 +40,11 @@ interface PlotSelectionProps {
   setSelectedPlot: (selected: boolean) => void;
 }
 interface ReviewPageProps {
-  selectedState: string | undefined;
+  selectedState: string;
   setSelectedState: (selected: string) => void;
-  selectedGardenType: UserTypeEnum | undefined;
+  selectedGardenType: UserTypeEnum;
   setSelectedGardenType: (selected: UserTypeEnum) => void;
-  selectedPlot: boolean | undefined;
+  selectedPlot: boolean;
   setSelectedPlot: (selected: boolean) => void;
 }
 
@@ -131,17 +131,20 @@ const ReviewPage = ({
   selectedPlot,
   setSelectedPlot,
 }: ReviewPageProps) => {
+  const { setProfile, setHasPlot } = useProfile();
+
   const handleSubmit = async () => {
     const profile: Profile = {
       user_id: '2abd7296-374a-42d1-bb4f-b813da1615ae',
-      us_state: selectedState!,
-      user_type: selectedGardenType!,
+      us_state: selectedState,
+      user_type: selectedGardenType,
       // has_plot: selectedPlot,
     };
 
     try {
-      await upsertProfile(profile);
+      await setProfile(profile);
       console.log('Profile submitted successfully:', profile);
+      setHasPlot(selectedPlot);
     } catch (error) {
       console.error('Error upserting profile:', error);
     }
@@ -153,20 +156,20 @@ const ReviewPage = ({
         <H3 style={{ textAlign: 'center' }}>Review Your Response</H3>
         <LabeledCustomSelect
           label="State Location"
-          value={selectedState!}
+          value={selectedState}
           options={stateOptions}
           onChange={setSelectedState}
         />
 
         <LabeledCustomSelect
           label="Garden Type"
-          value={selectedGardenType!}
+          value={selectedGardenType}
           options={gardenTypeOptions}
           onChange={setSelectedGardenType} // Directly pass the selected value
         />
         <LabeledCustomSelect
           label="Plot Status"
-          value={selectedPlot!}
+          value={selectedPlot}
           options={plotOptions}
           onChange={value => setSelectedPlot(value === true)} // Convert the value as needed
         />
@@ -221,9 +224,9 @@ export default function OnboardingFlow() {
         <ReviewPage
           selectedState={selectedState}
           setSelectedState={setSelectedState}
-          selectedGardenType={selectedGardenType}
+          selectedGardenType={selectedGardenType!}
           setSelectedGardenType={setSelectedGardenType}
-          selectedPlot={selectedPlot}
+          selectedPlot={selectedPlot!}
           setSelectedPlot={setSelectedPlot}
         />
       )}

--- a/types/schema.d.ts
+++ b/types/schema.d.ts
@@ -6,6 +6,8 @@ export type DifficultyLevelEnum = 'EASY' | 'MODERATE' | 'HARD';
 
 export type PlantingTypeEnum = 'INDOORS' | 'OUTDOORS' | 'TRANSPLANT';
 
+export type UserTypeEnum = 'INDIV' | 'SCHOOL' | 'ORG';
+
 export interface Profile {
   user_id: UUID;
   us_state: string;

--- a/utils/ProfileProvider.tsx
+++ b/utils/ProfileProvider.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import React, {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { UUID } from 'crypto';
+import {
+  fetchProfileById,
+  upsertProfile,
+} from '@/api/supabase/queries/profiles';
+import { Profile } from '@/types/schema';
+
+// Define a placeholder user ID for development purposes
+const placeholderUserId = '0802d796-ace8-480d-851b-d16293c74a21';
+
+export interface ProfileContextType {
+  profileData: Profile | null;
+  profileReady: boolean;
+  hasPlot: boolean | null;
+  setProfile: (completeProfile: Profile) => Promise<void>; // Now expects full Profile
+  loadProfile: () => Promise<void>;
+  setHasPlot: (plotValue: boolean | null) => void;
+}
+
+const ProfileContext = createContext<ProfileContextType | undefined>(undefined);
+
+export const useProfile = () => {
+  const context = useContext(ProfileContext);
+  if (!context) {
+    throw new Error('useProfile must be used within a ProfileProvider');
+  }
+  return context;
+};
+
+interface ProfileProviderProps {
+  children: ReactNode;
+}
+export default function ProfileProvider({ children }: ProfileProviderProps) {
+  const [profileData, setProfileData] = useState<Profile | null>(null);
+  const [profileReady, setProfileReady] = useState<boolean>(false);
+  const [hasPlot, setHasPlot] = useState<boolean | null>(null);
+
+  const loadProfile = useCallback(async (id?: UUID) => {
+    setProfileReady(false);
+
+    // If user isn't signed in, return null
+    if (!id && !placeholderUserId) {
+      setProfileReady(true);
+      return;
+    }
+
+    const fetchedProfile = await fetchProfileById(placeholderUserId);
+
+    setProfileData(fetchedProfile);
+    setProfileReady(true);
+  }, []);
+
+  useEffect(() => {
+    loadProfile();
+  }, [loadProfile]);
+
+  const setProfile = useCallback(async (completeProfile: Profile) => {
+    try {
+      const updatedProfile = await upsertProfile(completeProfile);
+      setProfileData(updatedProfile);
+      // Update has_plot if necessary by separate logic
+    } catch (error) {
+      console.error('Error setting profile:', error);
+      throw new Error('Error setting profile');
+    }
+  }, []);
+
+  const providerValue = useMemo(
+    () => ({
+      profileData,
+      profileReady,
+      hasPlot: hasPlot,
+      setProfile,
+      loadProfile,
+      setHasPlot,
+    }),
+    [profileData, profileReady, hasPlot, setProfile, loadProfile, setHasPlot],
+  );
+
+  return (
+    <ProfileContext.Provider value={providerValue}>
+      {children}
+    </ProfileContext.Provider>
+  );
+}


### PR DESCRIPTION
## What's new in this PR 🧑‍🌾
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
* applied ProfileContext created by https://github.com/calblueprint/trap-garden/pull/24
* refactor /onboarding page to use queries in ProfileContext

### Screenshots
[//]: # "Required for frontend changes, otherwise optional but strongly recommended. Add screenshots of expected behavior - GIFs if you're feeling fancy! Use the provided image template. Drag the desired image into the PR, then copy the link into the placeholder."

[image placeholder]: <img src="place image link here!!!" width="240" height="540">



## How to review
[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'
* review `/utils/ProfileProvider.tsx` 
* review `/app/onboarding/page.tsx` and test that `/onboarding` works as expected when running the app 

## Next steps
[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."
* connect Auth Context with ProfileContext → remove hardcoded userId and use the auth.id instead. Make sure that user's profile only appears if they're logged in. (see [IJP](https://github.com/calblueprint/immigration-justice-project/blob/main/src/utils/ProfileProvider.tsx) for an example)
* test if `setHasPlot` actually updates the value of `hasPlot` in the ProfileContext. we'll need to augment ProfileContext similarly for `selectedPlants/setSelectedPlants` in the add-details flow later. 


## Relevant links
### Online sources
[//]: # 'Copy links to any tutorials or documentation that was useful to you when working on this PR'



### Related PRs
[//]: # "Add related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"
* originally, https://github.com/calblueprint/trap-garden/pull/24


CC: @ccatherinetan
