### PR TITLE
[style] mobile view of plant card grid

### DIFF
--- a/app/view-plants/styles.ts
+++ b/app/view-plants/styles.ts
@@ -47,11 +47,15 @@ export const AddButtonContainer = styled.div`
 
 export const PlantGridContainer = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
-  /* grid-template-columns: repeat(auto-fill, 168px); */
+  grid-template-columns: repeat(auto-fill, 168px);
   gap: 8px;
-  max-width: 100%;
-  justify-content: center;
+  width: 100%;
+  justify-content: space-around;
+
+  // Mobile view: Two columns, equally spaced
+  @media (max-width: 392px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
 `;
 
 export const ViewSelection = styled.div`

--- a/components/PlantCard/styles.ts
+++ b/components/PlantCard/styles.ts
@@ -3,7 +3,8 @@ import COLORS from '@/styles/colors';
 
 export const CardContainer = styled.div<{ $isSelected?: boolean }>`
   position: relative;
-  width: 168px;
+  width: 100%; // let PlantGridContainer handle sizing
+  // max-width: 168px; // if PlantCard were used independently
   height: 200px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What's new in this PR 🧑‍🌾
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
- added media query in PlantGridContainer to ensure that on small mobile screens, each row has 2 PlantCards 
   - the 392px cutoff was calculated as: 24px (padding) x 2 + 168px (card size) x 2 + 8px (gap)
- note: the width of PlantCard currently is defined in `PlantGridContainer` as 168px. 
   - I've commented out the line that sets the max-width of PlantCard; this line can be uncommented if PlantCard is ever used independently of the grid view. 

### Screenshots
[//]: # "Required for frontend changes, otherwise optional but strongly recommended. Add screenshots of expected behavior - GIFs if you're feeling fancy! Use the provided image template. Drag the desired image into the PR, then copy the link into the placeholder."

[image placeholder]: <img src="place image link here!!!" width="240" height="540">

Mobile View 
<img width="355" alt="Screen Shot 2025-01-16 at 1 24 02 PM" src="https://github.com/user-attachments/assets/bdd3c1e0-481d-4917-bba9-8df249e8a7b9" />

Regular View 
<img width="1065" alt="Screen Shot 2025-01-16 at 1 24 16 PM" src="https://github.com/user-attachments/assets/33c05176-e634-4fc1-a128-8481d65808b7" />

## How to review
[//]: # 'Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'
- play around with different tab sizes on view-plants 

## Next steps
[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."
- decide if the `space-around` in PlantGridContainer is desired. 

## Relevant links
### Online sources
[//]: # 'Copy links to any tutorials or documentation that was useful to you when working on this PR'



### Related PRs
[//]: # "Add related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"



CC: @ccatherinetan
